### PR TITLE
Notebook Controller for runnable SQL cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## TODO
+
+- [ ] Look into [Notebook Controller](https://code.visualstudio.com/api/extension-guides/notebook#controller) to see how a cell can be run.
+
 # VSCode extension playground
 
 Play with the APIs for developing a VSCode extension


### PR DESCRIPTION
# WAT?
Look into [Notebook Controller](https://code.visualstudio.com/api/extension-guides/notebook#controller) to see how a cell can be run.

## TODO
- [ ] Allow only SQL cells. When you click on the `SQL` in a cell it gives the option to switch to another language. Check if there is a way of limiting it to sql.